### PR TITLE
use JSON::MaybeXS instead of JSON

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,9 +10,9 @@ WriteMakefile(
     ABSTRACT     => 'JSON Web Token',
     LICENSE      => 'perl',
     PREREQ_PM    => {
-      'MIME::Base64'        => '3.11',  # (en|de)code_base64url
-      'JSON'                => '2.01',  # (en|de)code_json
-      'Exporter'            => '5.59',  # we need: use Exporter 'import';
+      'MIME::Base64'        => '3.11',     # (en|de)code_base64url
+      'JSON::MaybeXS'       => '1.003005', # (en|de)code_json
+      'Exporter'            => '5.59',     # we need: use Exporter 'import';
       'Compress::Raw::Zlib' => 0,
       'CryptX'              => '0.024',
     },

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -12,7 +12,7 @@ our @EXPORT = qw();
 
 use Carp;
 use MIME::Base64 qw(decode_base64url encode_base64url);
-use JSON qw(decode_json encode_json);
+use JSON::MaybeXS qw(decode_json encode_json);
 use Crypt::PK::RSA;
 use Crypt::PK::ECC;
 use Crypt::PRNG qw(random_bytes);

--- a/t/jwt_params.t
+++ b/t/jwt_params.t
@@ -6,7 +6,7 @@ use Crypt::JWT qw(encode_jwt decode_jwt);
 use Crypt::PK::ECC;
 use Crypt::PK::RSA;
 use MIME::Base64 qw(encode_base64url);
-use JSON qw(encode_json);
+use JSON::MaybeXS qw(encode_json);
 
 # key password is 'secret'
 my $rsaPriv = <<'EOF';


### PR DESCRIPTION
Hi!

This PR substitutes the usage of JSON library with the state-of-the-art [JSON::MaybeXS](https://metacpan.org/pod/JSON::MaybeXS) wrapper, which defaults to correct and fast (XS) encoder/decoder backends.
