### PR TITLE
require claims to exist when asked to verify them

### DIFF
--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -1094,6 +1094,9 @@ C<1> - return decoded header as a return value of decode_jwt()
 
 =item verify_iss
 
+B<INCOMPATIBLE CHANGE in v0.24> - if C<verify_iss> is specified and
+claim C<iss> is completely missing it is a failure since v0.24
+
 C<CODE ref> - subroutine (with 'iss' claim value passed as argument) should return C<true> otherwise verification fails
 
 C<Regexp ref> - 'iss' claim value has to match given regexp otherwise verification fails
@@ -1101,6 +1104,9 @@ C<Regexp ref> - 'iss' claim value has to match given regexp otherwise verificati
 C<undef> (default) - do not verify 'iss' claim
 
 =item verify_aud
+
+B<INCOMPATIBLE CHANGE in v0.24> - if C<verify_aud> is specified and
+claim C<aud> is completely missing it is a failure since v0.24
 
 C<CODE ref> - subroutine (with 'aud' claim value passed as argument) should return C<true> otherwise verification fails
 
@@ -1110,6 +1116,9 @@ C<undef> (default) - do not verify 'aud' claim
 
 =item verify_sub
 
+B<INCOMPATIBLE CHANGE in v0.24> - if C<verify_sub> is specified and
+claim C<sub> is completely missing it is a failure since v0.24
+
 C<CODE ref> - subroutine (with 'sub' claim value passed as argument) should return C<true> otherwise verification fails
 
 C<Regexp ref> - 'sub' claim value has to match given regexp otherwise verification fails
@@ -1117,6 +1126,9 @@ C<Regexp ref> - 'sub' claim value has to match given regexp otherwise verificati
 C<undef> (default) - do not verify 'sub' claim
 
 =item verify_jti
+
+B<INCOMPATIBLE CHANGE in v0.24> - if C<verify_jti> is specified and
+claim C<jti> is completely missing it is a failure since v0.24
 
 C<CODE ref> - subroutine (with 'jti' claim value passed as argument) should return C<true> otherwise verification fails
 

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -168,43 +168,63 @@ sub _verify_claims {
   }
 
   ### iss
-  if(exists $payload->{iss}) {
-    if (ref $args{verify_iss} eq 'Regexp') {
-      croak "JWT: iss claim re check failed" unless $payload->{iss} =~ $args{verify_iss};
-    }
-    elsif (ref $args{verify_iss} eq 'CODE') {
-      croak "JWT: iss claim check failed" unless $args{verify_iss}->($payload->{iss});
-    }
+  if (exists $args{verify_iss}) {
+      if (exists $payload->{iss}) {
+          if (ref $args{verify_iss} eq 'Regexp') {
+              croak "JWT: iss claim re check failed" unless $payload->{iss} =~ $args{verify_iss};
+          }
+          elsif (ref $args{verify_iss} eq 'CODE') {
+              croak "JWT: iss claim check failed" unless $args{verify_iss}->($payload->{iss});
+          }
+      }
+      elsif ($args{verify_iss}) {
+          croak "JWT: iss claim required but missing"
+      }
   }
 
   ### sub
-  if(exists $payload->{sub}) {
-    if (ref $args{verify_sub} eq 'Regexp') {
-      croak "JWT: sub claim re check failed" unless $payload->{sub} =~ $args{verify_sub};
-    }
-    elsif (ref $args{verify_sub} eq 'CODE') {
-      croak "JWT: sub claim check failed" unless $args{verify_sub}->($payload->{sub});
-    }
+  if (exists $args{verify_sub}) {
+      if (exists $payload->{sub}) {
+          if (ref $args{verify_sub} eq 'Regexp') {
+              croak "JWT: sub claim re check failed" unless $payload->{sub} =~ $args{verify_sub};
+          }
+          elsif (ref $args{verify_sub} eq 'CODE') {
+              croak "JWT: sub claim check failed" unless $args{verify_sub}->($payload->{sub});
+          }
+      }
+      elsif ($args{verify_sub}) {
+          croak "JWT: sub claim required but missing"
+      }
   }
 
   ### aud
-  if(exists $payload->{aud}) {
-    if (ref $args{verify_aud} eq 'Regexp') {
-      croak "JWT: aud claim re check failed" unless $payload->{aud} =~ $args{verify_aud};
-    }
-    elsif (ref $args{verify_aud} eq 'CODE') {
-      croak "JWT: aud claim check failed" unless $args{verify_aud}->($payload->{aud});
-    }
+  if (exists $args{verify_aud}) {
+      if (exists $payload->{aud}) {
+          if (ref $args{verify_aud} eq 'Regexp') {
+              croak "JWT: aud claim re check failed" unless $payload->{aud} =~ $args{verify_aud};
+          }
+          elsif (ref $args{verify_aud} eq 'CODE') {
+              croak "JWT: aud claim check failed" unless $args{verify_aud}->($payload->{aud});
+          }
+      }
+      elsif ($args{verify_aud}) {
+          croak "JWT: aud claim required but missing"
+      }
   }
 
   ### jti
-  if(exists $payload->{jti}) {
-    if (ref $args{verify_jti} eq 'Regexp') {
-      croak "JWT: jti claim re check failed" unless $payload->{jti} =~ $args{verify_jti};
-    }
-    elsif (ref $args{verify_jti} eq 'CODE') {
-      croak "JWT: jti claim check failed" unless $args{verify_jti}->($payload->{jti});
-    }
+  if (exists $args{verify_jti}) {
+      if (exists $payload->{jti}) {
+          if (ref $args{verify_jti} eq 'Regexp') {
+              croak "JWT: jti claim re check failed" unless $payload->{jti} =~ $args{verify_jti};
+          }
+          elsif (ref $args{verify_jti} eq 'CODE') {
+              croak "JWT: jti claim check failed" unless $args{verify_jti}->($payload->{jti});
+          }
+      }
+      elsif ($args{verify_jti}) {
+          croak "JWT: jti claim required but missing"
+      }
   }
 }
 

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -169,62 +169,74 @@ sub _verify_claims {
 
   ### iss
   if (exists $args{verify_iss}) {
-      if (exists $payload->{iss}) {
-          if (ref $args{verify_iss} eq 'Regexp') {
-              croak "JWT: iss claim re check failed" unless $payload->{iss} =~ $args{verify_iss};
-          }
-          elsif (ref $args{verify_iss} eq 'CODE') {
-              croak "JWT: iss claim check failed" unless $args{verify_iss}->($payload->{iss});
-          }
+    if (exists $payload->{iss}) {
+      if (ref $args{verify_iss} eq 'Regexp') {
+        croak "JWT: iss claim re check failed" unless $payload->{iss} =~ $args{verify_iss};
       }
-      elsif ($args{verify_iss}) {
-          croak "JWT: iss claim required but missing"
+      elsif (ref $args{verify_iss} eq 'CODE') {
+        croak "JWT: iss claim check failed" unless $args{verify_iss}->($payload->{iss});
       }
+      else {
+        croak "JWT: verify_iss must be Regexp or CODE";
+      }
+    }
+    elsif ($args{verify_iss}) {
+      croak "JWT: iss claim required but missing"
+    }
   }
 
   ### sub
   if (exists $args{verify_sub}) {
-      if (exists $payload->{sub}) {
-          if (ref $args{verify_sub} eq 'Regexp') {
-              croak "JWT: sub claim re check failed" unless $payload->{sub} =~ $args{verify_sub};
-          }
-          elsif (ref $args{verify_sub} eq 'CODE') {
-              croak "JWT: sub claim check failed" unless $args{verify_sub}->($payload->{sub});
-          }
+    if (exists $payload->{sub}) {
+      if (ref $args{verify_sub} eq 'Regexp') {
+        croak "JWT: sub claim re check failed" unless $payload->{sub} =~ $args{verify_sub};
       }
-      elsif ($args{verify_sub}) {
-          croak "JWT: sub claim required but missing"
+      elsif (ref $args{verify_sub} eq 'CODE') {
+        croak "JWT: sub claim check failed" unless $args{verify_sub}->($payload->{sub});
       }
+      else {
+        croak "JWT: verify_sub must be Regexp or CODE";
+      }
+    }
+    elsif ($args{verify_sub}) {
+      croak "JWT: sub claim required but missing"
+    }
   }
 
   ### aud
   if (exists $args{verify_aud}) {
-      if (exists $payload->{aud}) {
-          if (ref $args{verify_aud} eq 'Regexp') {
-              croak "JWT: aud claim re check failed" unless $payload->{aud} =~ $args{verify_aud};
-          }
-          elsif (ref $args{verify_aud} eq 'CODE') {
-              croak "JWT: aud claim check failed" unless $args{verify_aud}->($payload->{aud});
-          }
+    if (exists $payload->{aud}) {
+      if (ref $args{verify_aud} eq 'Regexp') {
+        croak "JWT: aud claim re check failed" unless $payload->{aud} =~ $args{verify_aud};
       }
-      elsif ($args{verify_aud}) {
-          croak "JWT: aud claim required but missing"
+      elsif (ref $args{verify_aud} eq 'CODE') {
+        croak "JWT: aud claim check failed" unless $args{verify_aud}->($payload->{aud});
       }
+      else {
+        croak "JWT: verify_aud must be Regexp or CODE";
+      }
+    }
+    elsif ($args{verify_aud}) {
+      croak "JWT: aud claim required but missing"
+    }
   }
 
   ### jti
   if (exists $args{verify_jti}) {
-      if (exists $payload->{jti}) {
-          if (ref $args{verify_jti} eq 'Regexp') {
-              croak "JWT: jti claim re check failed" unless $payload->{jti} =~ $args{verify_jti};
-          }
-          elsif (ref $args{verify_jti} eq 'CODE') {
-              croak "JWT: jti claim check failed" unless $args{verify_jti}->($payload->{jti});
-          }
+    if (exists $payload->{jti}) {
+      if (ref $args{verify_jti} eq 'Regexp') {
+        croak "JWT: jti claim re check failed" unless $payload->{jti} =~ $args{verify_jti};
       }
-      elsif ($args{verify_jti}) {
-          croak "JWT: jti claim required but missing"
+      elsif (ref $args{verify_jti} eq 'CODE') {
+        croak "JWT: jti claim check failed" unless $args{verify_jti}->($payload->{jti});
       }
+      else {
+        croak "JWT: verify_jti must be Regexp or CODE";
+      }
+    }
+    elsif ($args{verify_jti}) {
+      croak "JWT: jti claim required but missing"
+    }
   }
 }
 

--- a/t/jwt_params.t
+++ b/t/jwt_params.t
@@ -218,6 +218,16 @@ for ([qw/PBES2-HS256+A128KW A128GCM/], ['HS512', '']) {
     ok(time - $iat < 2, "auto_iat/2");
     is($decoded->{nbf}, $iat-13,  "relative_nbf/2: alg=>'$alg'");
     is($decoded->{exp}, $iat-4, "relative_exp/2: alg=>'$alg'");
+
+    $token = encode_jwt(key=>$k, payload=>{}, alg=>$alg);
+    $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_iss=>sub { return 1 }) };
+    is($decoded, undef, "decoded - missing_claims/1: alg=>'$alg'");
+    $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_sub=>sub { return 1 }) };
+    is($decoded, undef, "decoded - missing_claims/2: alg=>'$alg'");
+    $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_aud=>sub { return 1 }) };
+    is($decoded, undef, "decoded - missing_claims/3: alg=>'$alg'");
+    $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_jti=>sub { return 1 }) };
+    is($decoded, undef, "decoded - missing_claims/4: alg=>'$alg'");
   }
 }
 


### PR DESCRIPTION
I would expect that calling `decode_jwt` with `verify_iss` would die if there is no `iss` claim to verify (same for `sub`, `aud`, `jti`)

This commit makes that happen.

Possible incompatible change:

```perl
decode_jwt(token=>encode_jwt(payload=>{},@etc),verify_iss=>sub{1},@etc);
```

used to work, now it fails. Maybe if the `verify_*` is a CODE, we should call it with whatever value we have (`undef` if missing) and trust it?