### PR TITLE
_verify_claims: Refactor iss, sub, aud, and jti checks

### DIFF
--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -167,77 +167,29 @@ sub _verify_claims {
     }
   }
 
-  ### iss
-  if (exists $args{verify_iss}) {
-    if (exists $payload->{iss}) {
-      if (ref $args{verify_iss} eq 'Regexp') {
-        croak "JWT: iss claim re check failed" unless $payload->{iss} =~ $args{verify_iss};
+  ### iss, sub, aud, jti
+  foreach my $claim (qw(iss sub aud jti)) {
+    my $check = $args{"verify_$claim"};
+    next unless (defined $check);
+
+    if (exists $payload->{$claim}) {
+      if (ref $check eq 'Regexp') {
+        my $value = $payload->{$claim};
+        $value = "" if !defined $value;
+        croak "JWT: $claim claim re check failed" unless $value =~ $check;
       }
-      elsif (ref $args{verify_iss} eq 'CODE') {
-        croak "JWT: iss claim check failed" unless $args{verify_iss}->($payload->{iss});
+      elsif (ref $check eq 'CODE') {
+        croak "JWT: $claim claim check failed" unless $check->($payload->{$claim});
       }
       else {
-        croak "JWT: verify_iss must be Regexp or CODE";
+        croak "JWT: verify_$claim must be Regexp or CODE";
       }
     }
-    elsif ($args{verify_iss}) {
-      croak "JWT: iss claim required but missing"
+    else {
+      croak "JWT: $claim claim required but missing"
     }
   }
 
-  ### sub
-  if (exists $args{verify_sub}) {
-    if (exists $payload->{sub}) {
-      if (ref $args{verify_sub} eq 'Regexp') {
-        croak "JWT: sub claim re check failed" unless $payload->{sub} =~ $args{verify_sub};
-      }
-      elsif (ref $args{verify_sub} eq 'CODE') {
-        croak "JWT: sub claim check failed" unless $args{verify_sub}->($payload->{sub});
-      }
-      else {
-        croak "JWT: verify_sub must be Regexp or CODE";
-      }
-    }
-    elsif ($args{verify_sub}) {
-      croak "JWT: sub claim required but missing"
-    }
-  }
-
-  ### aud
-  if (exists $args{verify_aud}) {
-    if (exists $payload->{aud}) {
-      if (ref $args{verify_aud} eq 'Regexp') {
-        croak "JWT: aud claim re check failed" unless $payload->{aud} =~ $args{verify_aud};
-      }
-      elsif (ref $args{verify_aud} eq 'CODE') {
-        croak "JWT: aud claim check failed" unless $args{verify_aud}->($payload->{aud});
-      }
-      else {
-        croak "JWT: verify_aud must be Regexp or CODE";
-      }
-    }
-    elsif ($args{verify_aud}) {
-      croak "JWT: aud claim required but missing"
-    }
-  }
-
-  ### jti
-  if (exists $args{verify_jti}) {
-    if (exists $payload->{jti}) {
-      if (ref $args{verify_jti} eq 'Regexp') {
-        croak "JWT: jti claim re check failed" unless $payload->{jti} =~ $args{verify_jti};
-      }
-      elsif (ref $args{verify_jti} eq 'CODE') {
-        croak "JWT: jti claim check failed" unless $args{verify_jti}->($payload->{jti});
-      }
-      else {
-        croak "JWT: verify_jti must be Regexp or CODE";
-      }
-    }
-    elsif ($args{verify_jti}) {
-      croak "JWT: jti claim required but missing"
-    }
-  }
 }
 
 sub _payload_zip {

--- a/t/jwt_params.t
+++ b/t/jwt_params.t
@@ -160,6 +160,13 @@ for ([qw/PBES2-HS256+A128KW A128GCM/], ['HS512', '']) {
     $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_iss=>qr/string/, verify_aud=>qr/string/, verify_sub=>qr/string/, verify_jti=>qr/BADVAL/) };
     is($decoded, undef, "decoded - claims/11: alg=>'$alg'");
 
+    # check for undef payload values or undef verify args
+    $token = encode_jwt(key=>$k, payload=>{iat=>time, nbf=>time, exp=>time+10, iss=>undef, aud=>undef, sub=>undef, jti=>undef, data=>'Hello'}, alg=>$alg);
+    $decoded = eval { decode_jwt(key=>$k, token=>$token, verify_iss=>qr/string/, verify_aud=>qr/string/, verify_sub=>qr/string/, verify_jti=>qr/BADVAL/) };
+    is($decoded, undef, "decoded - claims_undef/1: alg=>'$alg'");
+    $decoded = decode_jwt(key=>$k, token=>$token, verify_iss=>undef, verify_aud=>undef, verify_sub=>undef, verify_jti=>undef);
+    is($decoded->{data}, 'Hello', "decoded - claims_undef/2: alg=>'$alg'");
+
     # iat
     $token = encode_jwt(key=>$k, payload=>{iat=>time+10, nbf=>time, exp=>time+10, data=>'Hello'}, alg=>$alg);
     $decoded = eval { decode_jwt(key=>$k, token=>$token) };


### PR DESCRIPTION
* In the latest version of `Crypt::JWT`, I had a dev get caught out on
  setting `verify_iss => undef` and `verify_aud => undef` in a call to
  `decode_jwt`. This is a problem because the documentation specifically
  says the default value of these args is `undef`, e.g.:
```
    verify_aud
        INCOMPATIBLE CHANGE in 0.024: If "verify_aud" is
        specified and claim "aud" (Audience) is completely
        missing it is a failure since 0.024

        "CODE ref" - subroutine (with 'aud' claim value
        passed as argument) should return "true" otherwise
        verification fails

        "Regexp ref" - 'aud' claim value has to match given
        regexp otherwise verification fails

        "undef" (default) - do not verify 'aud' claim
```
  In reality the code was checking for the *existence* of the argument
  rather than if it were defined or not and hence failed on the last
  conditional (`JWT: <x> must be Regexp or CODE`).

  Rather than target that specifically, I've taken the liberty of
  compressing all of these similar checks into a single loop which does
  the same thing being done before, but without the repetition (DRY!),
  and proper handling of undef args.