### PR TITLE
Speed up decode_jwt

### DIFF
--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -761,13 +761,14 @@ sub decode_jwt {
   if (!$args{token}) {
     croak "JWT: missing token";
   }
-  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*$/) {
-    # JWE token (5 segments)
-    ($header, $payload) = _decode_jwe($1, $2, $3, $4, $5, undef, {}, {}, %args);
-  }
-  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*$/) {
-    # JWS token (3 segments)
-    ($header, $payload) = _decode_jws($1, $2, $3, {}, %args);
+  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]+)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/) {
+    if (length($5)) {
+        # JWE token (5 segments)
+        ($header, $payload) = Crypt::JWT::_decode_jwe($1, $2, $3, $4, $5, undef, {}, {}, %args);
+    } else {
+        # JWS token (3 segments)
+        ($header, $payload) = Crypt::JWT::_decode_jws($1, $2, $3, {}, %args);
+    }
   }
   elsif ($args{token} =~ /^\s*\{.*?\}\s*$/s) {
     my $hash = decode_json($args{token});

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -761,7 +761,7 @@ sub decode_jwt {
   if (!$args{token}) {
     croak "JWT: missing token";
   }
-  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]+)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/) {
+  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]*)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/) {
     if (length($5)) {
         # JWE token (5 segments)
         ($header, $payload) = Crypt::JWT::_decode_jwe($1, $2, $3, $4, $5, undef, {}, {}, %args);


### PR DESCRIPTION
I noticed that for large tokens (not *huge*, just a couple dozen kb), especially for JWS, the decode function was very slow, and it looks like most of the runtime (90% in my case) was spent by the regex. While large tokens are probably not common, I thought I'd make it faster.

This is some benchmarking code:
```
my $data = "The rain in Spain stays mainly in the plain." x 10000;
my $key  = '-----BEGIN PRIVATE KEY-----
    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYirTZSx+5O8Y6tlG
    cka6W6btJiocdrdolfcukSoTEk+hRANCAAQkvPNu7Pa1GcsWU4v7ptNfqCJVq8Cx
    zo0MUVPQgwJ3aJtNM1QMOQUayCrRwfklg+D/rFSUwEUqtZh7fJDiFqz3
    -----END PRIVATE KEY-----';

my $token = encode_jwt(
    payload => $data,
    alg     => 'ES256',
    key     => \$key,
);

cmpthese(-2, {
    decode_jwt => sub {
        my $out = decode_jwt(token=>$token, key=>\$key);
    },
    decode_jwt2 => sub {
        my $out = decode_jwt2(token=>$token, key=>\$key);
    },
});
```
Where `decode_jwt2` is the version on this PR.
In this (extreme) example the overall speedup of decode is over 4x with perl 5.38.0:
```
              Rate  decode_jwt decode_jwt2
decode_jwt  37.8/s          --        -78%
decode_jwt2  169/s        345%          --
```
