### PR TITLE
don't croak on an unknown zip method while unzipping the payload

### DIFF
--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -271,9 +271,6 @@ sub _payload_unzip {
     croak "JWT: inflate failed" unless $output;
     $payload = $output;
   }
-  else {
-    croak "JWT: unknown zip method '$z'";
-  }
   return $payload;
 }
 


### PR DESCRIPTION
LinkedIn's OpenID puts an "RS256" into the "zip" property of the JWT header. Which might be wrong obviously as the rest of the payload is uncompressed. So better ignore this and return the payload as is.
