### PR TITLE
Allow decoding JWS with Base64 padding characters

### DIFF
--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -819,7 +819,10 @@ sub decode_jwt {
   if (!$args{token}) {
     croak "JWT: missing token";
   }
-  elsif ($args{token} =~ /^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]*)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/) {
+  my $token_re = $args{keep_padding}
+    ? qr/^([a-zA-Z0-9_-]+=*)\.([a-zA-Z0-9_-]*=*)\.([a-zA-Z0-9_-]*=*)(?:\.([a-zA-Z0-9_-]+=*)\.([a-zA-Z0-9_-]+=*))?$/
+    : qr/^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]*)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/;
+  if ($args{token} =~ $token_re) {
     if (defined($5) && length($5) > 0) {
         # JWE token (5 segments)
         ($header, $payload) = _decode_jwe($1, $2, $3, $4, $5, undef, {}, {}, %args);

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -1288,6 +1288,12 @@ C<Scalar> - 'typ' header parameter value has to be equal to given string
 
 C<undef> (default) - do not verify 'typ' header parameter
 
+=item keep_padding
+
+C<0> (default) - ignore Base64 padding characters when validating signature
+
+C<1> - take account of Base64 padding characters when validating signature
+
 =back
 
 =head2 encode_jwt

--- a/lib/Crypt/JWT.pm
+++ b/lib/Crypt/JWT.pm
@@ -819,7 +819,7 @@ sub decode_jwt {
   if (!$args{token}) {
     croak "JWT: missing token";
   }
-  my $token_re = $args{keep_padding}
+  my $token_re = $args{tolerate_padding}
     ? qr/^([a-zA-Z0-9_-]+=*)\.([a-zA-Z0-9_-]*=*)\.([a-zA-Z0-9_-]*=*)(?:\.([a-zA-Z0-9_-]+=*)\.([a-zA-Z0-9_-]+=*))?$/
     : qr/^([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]*)=*\.([a-zA-Z0-9_-]*)=*(?:\.([a-zA-Z0-9_-]+)=*\.([a-zA-Z0-9_-]+)=*)?$/;
   if ($args{token} =~ $token_re) {
@@ -1288,7 +1288,7 @@ C<Scalar> - 'typ' header parameter value has to be equal to given string
 
 C<undef> (default) - do not verify 'typ' header parameter
 
-=item keep_padding
+=item tolerate_padding
 
 C<0> (default) - ignore Base64 padding characters when validating signature
 

--- a/t/jws_with_padding.t
+++ b/t/jws_with_padding.t
@@ -30,7 +30,7 @@ EOF
 # EOF
 
 my $token = 'eyJhbGciOiJFUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIn0=.FOGAeCGvhKs-sQPUWQEmpdM0kC_yfi986ZW7XoT4pnlTKRLn43wDw6zVHdzEFFuy_JgsQFGYCfJQQds-5FF05w==';
-my $decoded = decode_jwt(token => $token, keep_padding => 1, decode_payload => 0, key => \$ecc256Pub);
+my $decoded = decode_jwt(token => $token, tolerate_padding => 1, decode_payload => 0, key => \$ecc256Pub);
 is $decoded, '{"hello":"world"}';
 
 done_testing;

--- a/t/jws_with_padding.t
+++ b/t/jws_with_padding.t
@@ -30,7 +30,13 @@ EOF
 # EOF
 
 my $token = 'eyJhbGciOiJFUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIn0=.FOGAeCGvhKs-sQPUWQEmpdM0kC_yfi986ZW7XoT4pnlTKRLn43wDw6zVHdzEFFuy_JgsQFGYCfJQQds-5FF05w==';
-my $decoded = decode_jwt(token => $token, tolerate_padding => 1, decode_payload => 0, key => \$ecc256Pub);
-is $decoded, '{"hello":"world"}';
+my $decoded;
+
+$decoded = eval { decode_jwt(token => $token, decode_payload => 0, key => \$ecc256Pub) };
+is($decoded, undef, 'default (tolerate_padding => 0)');
+$decoded = eval { decode_jwt(token => $token, tolerate_padding => 0, decode_payload => 0, key => \$ecc256Pub) };
+is($decoded, undef, 'tolerate_padding => 0');
+$decoded = eval { decode_jwt(token => $token, tolerate_padding => 1, decode_payload => 0, key => \$ecc256Pub) };
+is($decoded, '{"hello":"world"}', 'tolerate_padding => 1');
 
 done_testing;

--- a/t/jws_with_padding.t
+++ b/t/jws_with_padding.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Crypt::JWT qw(decode_jwt);
+
+my $ecc256Pub = <<EOF;
+-----BEGIN PUBLIC KEY-----
+MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAA
+AAAAAAAAAAD///////////////8wRAQg/////wAAAAEAAAAAAAAAAAAAAAD/////
+//////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvOPD4n0mBLBEEEaxfR
+8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84z
+V2sxXs7LtkBoN79R9QIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVR
+AgEBA0IABLCZs5f55I9TnS52ClM2LY7Ui+9fVn1W7BAEmsgDbrY2J74jFoU+Rw4A
+xlGgQNgAcsaX6u9exFUjJHQLL8wnZ0o=
+-----END PUBLIC KEY-----
+EOF
+
+# my $ecc256Priv = <<'EOF';
+# -----BEGIN EC PRIVATE KEY-----
+# MIIBUQIBAQQg7hVSXtl+9yGHEYCsC6f11j/y3DX3NdDW0kQoO8EO9pmggeMwgeAC
+# AQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAAAAAAAAAAAAAA////////////////
+# MEQEIP////8AAAABAAAAAAAAAAAAAAAA///////////////8BCBaxjXYqjqT57Pr
+# vVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwRBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLesz
+# oPShOUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////
+# AAAAAP//////////vOb6racXnoTzucrC/GMlUQIBAaFEA0IABLCZs5f55I9TnS52
+# ClM2LY7Ui+9fVn1W7BAEmsgDbrY2J74jFoU+Rw4AxlGgQNgAcsaX6u9exFUjJHQL
+# L8wnZ0o=
+# -----END EC PRIVATE KEY-----
+# EOF
+
+my $token = 'eyJhbGciOiJFUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIn0=.FOGAeCGvhKs-sQPUWQEmpdM0kC_yfi986ZW7XoT4pnlTKRLn43wDw6zVHdzEFFuy_JgsQFGYCfJQQds-5FF05w==';
+my $decoded = decode_jwt(token => $token, keep_padding => 1, decode_payload => 0, key => \$ecc256Pub);
+is $decoded, '{"hello":"world"}';
+
+done_testing;

--- a/t/jws_with_padding.t
+++ b/t/jws_with_padding.t
@@ -4,7 +4,7 @@ use Test::More;
 
 use Crypt::JWT qw(decode_jwt);
 
-my $ecc256Pub = <<EOF;
+my $ecc256Pub = <<'EOF';
 -----BEGIN PUBLIC KEY-----
 MIIBMzCB7AYHKoZIzj0CATCB4AIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAA
 AAAAAAAAAAD///////////////8wRAQg/////wAAAAEAAAAAAAAAAAAAAAD/////


### PR DESCRIPTION
Some JWT implementation generates tokens with Base64 padding characters. This pull request adds an option to decode those tokens.

Fixes #43